### PR TITLE
fix(cdk-build): align the build env with cdk-deploy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,9 @@ name: Build
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review, edited]
+  push:
+    branches:
+      - gh-readonly-queue/**
   merge_group:
     types: [checks_requested]
   workflow_dispatch: {}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,9 @@ name: Build
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review, edited]
+  # The merge queue needs `build` and `Lint PR title` to report on the
+  # queue ref. merge_group alone was not dispatching, so mirror the
+  # push-on-queue-ref trigger the review workflows already use.
   push:
     branches:
       - gh-readonly-queue/**

--- a/action.yml
+++ b/action.yml
@@ -60,5 +60,8 @@ runs:
       env:
         CDK_DEPLOY_ACCOUNT: ${{ inputs.cdk_deploy_account }}
         CDK_DEPLOY_REGION: ${{ inputs.cdk_deploy_region }}
+        CDK_DEFAULT_ACCOUNT: ${{ inputs.cdk_deploy_account }}
+        CDK_DEFAULT_REGION: ${{ inputs.cdk_deploy_region }}
         AWS_REGION: ${{ inputs.aws_region }}
+        P6_DFZ_SRC_P6M7G8_DOTFILES_DIR: ".deps"
       run: ${{ inputs.p6_custom_build_cmd }}


### PR DESCRIPTION
**What:** Adds the three env vars `cdk-build`'s build step was missing relative to its sibling `cdk-deploy` (`CDK_DEFAULT_ACCOUNT`, `CDK_DEFAULT_REGION`, `P6_DFZ_SRC_P6M7G8_DOTFILES_DIR`), plus the `gh-readonly-queue` push-trigger rider on `.github/workflows/build.yml`.

**Why:**

I compared the `env:` blocks of `cdk-build/action.yml` and `cdk-deploy/action.yml` directly. Three variables were present in deploy and absent in build. After this change the two `env:` blocks are byte-identical (verified programmatically). Per variable, why it belongs in a build:

| Variable | Why it belongs in a synth/diff |
|---|---|
| `CDK_DEFAULT_ACCOUNT` | CDK resolves `Stack.of(this).account` and the env-agnostic vs env-specific decision at **synth** time, not deploy time. `pnpm run diff` synthesises. Without it, synth emits env-agnostic templates using `AWS::AccountId` pseudo-parameters instead of the concrete account, so the diff rendered on the PR is not the template deploy will produce. |
| `CDK_DEFAULT_REGION` | Same mechanism for region. Also gates region-dependent synth behaviour (AZ enumeration, region-keyed lookup tables). Absent, synth silently picks a different region context than deploy will. |
| `P6_DFZ_SRC_P6M7G8_DOTFILES_DIR` | The action checks out `p6common`, `p6aws`, `p6awscdk` and `p6-cirrus` into `.deps/*`. This variable is the **only** pointer to that root. Without it the build cannot locate any of the four checkouts, which makes those four checkout steps dead weight today. |

Deliberately **not** copied from deploy: the `Make ~/.aws` step. Creating `~/.aws` is a deploy-time concern for credential-file writing and is not needed by a synth/diff, so blindly copying it would have been scope creep.

Rider context: `merge_group` stopped dispatching org-wide, so `build` never reported on `gh-readonly-queue` refs and PRs were dequeued at the 7-minute check timeout. `claude-review.yml` and `pull-request-lint.yml` already carry this trigger, which is why only `build` went unreported. The added trigger matches their proven form exactly.

**Test plan:**
- `actionlint .github/workflows/*.yml` clean (all 10 workflows).
- `python3 -c "import yaml; yaml.safe_load(open('action.yml'))"` parses.
- Programmatic diff of the two `env:` blocks confirms `cdk-build` now matches `cdk-deploy`.
- Extracted every `run:` block to a temp file and ran `shellcheck -S warning -s bash`. Clean. The single hit on `run: ${{ inputs.p6_custom_build_cmd }}` (SC2288/SC2296/SC1083) is an artifact of extracting GHA template syntax into a standalone script; GitHub substitutes the expression before bash sees it, and `cdk-deploy` carries the identical line.
- `act pull_request -W .github/workflows/build.yml -j build --dryrun` succeeds and resolves the full composite action graph. A non-dryrun `act` run fails at `actions/checkout` with `git clone: some refs were not updated` because the wrapper fetches by SHA from the remote; this is a known local-runner limitation, not a defect in this change, so verification relies on the remote GHA run.

**Dependencies:** Depends on Wave 1 (all merged).